### PR TITLE
Fix: Implement cancelOnDisconnect

### DIFF
--- a/lib/src/windows/bluetooth_characteristic_windows.dart
+++ b/lib/src/windows/bluetooth_characteristic_windows.dart
@@ -53,6 +53,9 @@ class BluetoothCharacteristicWindows extends BluetoothCharacteristic {
 
   String get _key => "$serviceUuid:$characteristicUuid";
 
+  BluetoothDevice get device =>
+      FlutterBluePlusWindows.connectedDevices.firstWhere((device) => device.remoteId == remoteId);
+
   /// this variable is updated:
   ///   - anytime `read()` is called
   ///   - anytime `write()` is called


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

READY

## Description

Implements `cancelOnDisconnect` to fix #15. One side effect of this change is that a `StateError` will be thrown if the device is not connected and `characteristic.device` is accessed. In FlutterBluePlus, a new `BluetoothDevice` is created from this getter, since it only needs the `remoteId` to be constructed, whereas in FlutterBluePlusWindows, `BluetoothDeviceWindows` requires `platformName` which is not available from the characteristic. Let me know if you believe this should be refactored to prevent this.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
