### PR TITLE
Fix company ID in manufacturer data

### DIFF
--- a/lib/src/windows/flutter_blue_plus_windows.dart
+++ b/lib/src/windows/flutter_blue_plus_windows.dart
@@ -215,7 +215,7 @@ class FlutterBluePlusWindows {
           final manufacturerData = winBleDevice.manufacturerData.isNotEmpty
               ? {
                   if (winBleDevice.manufacturerData.length >= 2)
-                    winBleDevice.manufacturerData[0]: winBleDevice.manufacturerData.sublist(2),
+                    winBleDevice.manufacturerData[0] + (winBleDevice.manufacturerData[1] << 8): winBleDevice.manufacturerData.sublist(2),
                 }
               : scanResult?.advertisementData.manufacturerData ?? {};
 


### PR DESCRIPTION
## Status

READY

## Description

The company ID consists of two bytes, but in the current implementation the second byte was ignored. That was fixed in this branch.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
